### PR TITLE
RPL_MYINFO (004) refers to a <version> string in RPL_CREATED (003), but it should to refer to RPL_YOURHOST (002)

### DIFF
--- a/refs/numerics/004.md
+++ b/refs/numerics/004.md
@@ -41,7 +41,7 @@ The `RPL_MYINFO (004)` numeric is part of the initial registration burst when ne
 - `<available cmodes>`: List of available channel modes.
 - `<cmodes with param>`: List of channel modes that take a parameter.
 
-The `<version>` string is similar to the one used for [`RPL_CREATED (003)`](003.html), but it MUST NOT contain any spaces.
+The `<version>` string is similar to the one used for [`RPL_YOURHOST (002)`](002.html), but it MUST NOT contain any spaces.
 
 The `<available ...>` parameters list the user and channel modes which clients can set. However, users SHOULD discover available features using the appropriate [`RPL_ISUPPORT` parameters](https://modern.ircdocs.horse/#rplisupport-parameters) rather than using the parameters of this numeric.
 


### PR DESCRIPTION
Fix reference for the version parameter, reported by Moku